### PR TITLE
fix typo

### DIFF
--- a/languages/slash-admin-el.po
+++ b/languages/slash-admin-el.po
@@ -1320,7 +1320,7 @@ msgid "Prefetch homepage"
 msgstr "Prefetch αρχικής σελίδας"
 
 #: options.php:1238
-msgid "Prefetch homepage when on sigle posts and pages."
+msgid "Prefetch homepage when on single posts and pages."
 msgstr ""
 "Prefetch αρχικής σελίδας όταν βρισκόμαστε σε μεμονωμένα άρθρα και σελίδες."
 
@@ -1329,7 +1329,7 @@ msgid "Prerender homepage"
 msgstr "Prerender αρχικής σελίδας"
 
 #: options.php:1245
-msgid "Prerender homepage when on sigle posts and pages."
+msgid "Prerender homepage when on single posts and pages."
 msgstr ""
 "Prerender αρχικής σελίδας όταν βρισκόμαστε σε μεμονωμένα άρθρα και σελίδες."
 

--- a/languages/slash-admin.pot
+++ b/languages/slash-admin.pot
@@ -1148,7 +1148,7 @@ msgid "Prefetch homepage"
 msgstr ""
 
 #: options.php:1238
-msgid "Prefetch homepage when on sigle posts and pages."
+msgid "Prefetch homepage when on single posts and pages."
 msgstr ""
 
 #: options.php:1244
@@ -1156,7 +1156,7 @@ msgid "Prerender homepage"
 msgstr ""
 
 #: options.php:1245
-msgid "Prerender homepage when on sigle posts and pages."
+msgid "Prerender homepage when on single posts and pages."
 msgstr ""
 
 #: options.php:1260

--- a/options.php
+++ b/options.php
@@ -1261,14 +1261,14 @@ class Slash_Admin_Options {
 		$this->settings['prefetch_home']             = array(
 			'section' => 'performance',
 			'title'   => __( 'Prefetch homepage', 'slash-admin' ),
-			'desc'    => __( 'Prefetch homepage when on sigle posts and pages.', 'slash-admin' ),
+			'desc'    => __( 'Prefetch homepage when on single posts and pages.', 'slash-admin' ),
 			'type'    => 'checkbox',
 			'std'     => 0,
 		);
 		$this->settings['prerender_home']            = array(
 			'section' => 'performance',
 			'title'   => __( 'Prerender homepage', 'slash-admin' ),
-			'desc'    => __( 'Prerender homepage when on sigle posts and pages.', 'slash-admin' ),
+			'desc'    => __( 'Prerender homepage when on single posts and pages.', 'slash-admin' ),
 			'type'    => 'checkbox',
 			'std'     => 0,
 		);


### PR DESCRIPTION
Fixing typo for the word 'single' in options.php and language files. 